### PR TITLE
Update paging.js

### DIFF
--- a/src/components/paging.js
+++ b/src/components/paging.js
@@ -8,16 +8,21 @@ export default {
         var UI = function() {
             var activePage = 1, lastPage = 1;
             var $main = null;
-
+            var cnt = 0;
+            
             function setEventAction(self) {
                 self.addEvent($(self.root).find(".prev"), "click", function(e) {
-                    self.prev();
+                    cnt++;
+                    if(cnt == 1) self.prev();
+                    window.setTimeout(function(){cnt = 0;}, 500);
                     return false;
                 });
 
                 self.addEvent($(self.root).find(".next"), "click", function(e) {
-                    self.next();
-                    return false;
+                    cnt++;
+                    if (cnt == 1) self.next();
+                    window.setTimeout(function(){cnt = 0;}, 500);
+                    return false;                
                 });
             }
 


### PR DESCRIPTION
next, prev 버튼 클릭시 PC환경에서는 잘되나 모바일 환경에서는 뺑뺑이 도는 현상이 있습니다.
하여 이를 timeout을 통하여 처리 하였습니다.

             var cnt = 0;
	
	function setEventAction(self) {
		self.addEvent($(self.root).find(".prev"), "click", function(e) {
			cnt++;
			if(cnt == 1) self.prev();
			window.setTimeout(function(){cnt = 0;}, 500);
			return false;
		});

		self.addEvent($(self.root).find(".next"), "click", function(e) {
			cnt++;
			if (cnt == 1) self.next();
			window.setTimeout(function(){cnt = 0;}, 500);
			return false;
		});
	}
이점 참고 해주시면 감사 하겠습니다.